### PR TITLE
Change Travis job to solve issue on log length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
     - pushd farao-community/farao-core && mvn -DskipTests install && popd
 
 script:
-- mvn clean verify sonar:sonar
+- mvn --batch-mode clean verify sonar:sonar


### PR DESCRIPTION
Signed-off-by: Sébastien MURGEY <sebastien.murgey@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bugfix


**What is the current behavior?** *(You can also link to an open issue here)*
Withe newer versions of powsybl-gse, Travis job blocks due to a message indicating that log file is too long.


**What is the new behavior (if this is a feature change)?**
The Travis jobs should not be blocked anymore

